### PR TITLE
Convert to Container Action

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 4'
+
+env:
+  DOCKER_BUILDKIT: 1
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Test Action
+      uses: ./

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -7,9 +7,6 @@ on:
   schedule:
     - cron: '0 0 * * 4'
 
-env:
-  DOCKER_BUILDKIT: 1
-
 jobs:
 
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:experimental
-
 FROM ubuntu:20.04
 
 RUN apt-get update -qq \
@@ -20,9 +18,11 @@ RUN mkdir verible \
 
 ENV GOBIN=/opt/go/bin
 
+# FIXME This layer might be avoid by using BuildKit and --mount=type=bind
+COPY reviewdog.patch /tmp/reviewdog/reviewdog.patch
+
 # Install reviewdog
-RUN --mount=type=bind,src=.,target=/tmp/reviewdog \
- git clone https://github.com/reviewdog/reviewdog \
+RUN git clone https://github.com/reviewdog/reviewdog \
  && cd reviewdog \
  && git checkout 72c205e138df049330f2a668c33782cda55d61f6 \
  && git apply /tmp/reviewdog/reviewdog.patch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:experimental
+
+FROM ubuntu:20.04
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    golang-go \
+    python3 \
+    python3-click \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir verible \
+ && curl -fsSL https://github.com/google/verible/releases/download/v0.0-1213-g9e5c085/verible-v0.0-1213-g9e5c085-Ubuntu-20.04-focal-x86_64.tar.gz | tar -zxvf - -C verible --strip-components=1 \
+ && for i in ./verible/bin/*; do ln -s $i /bin/$(basename $i); done
+
+ENV GOBIN=/opt/go/bin
+
+# Install reviewdog
+RUN --mount=type=bind,src=.,target=/tmp/reviewdog \
+ git clone https://github.com/reviewdog/reviewdog \
+ && cd reviewdog \
+ && git checkout 72c205e138df049330f2a668c33782cda55d61f6 \
+ && git apply /tmp/reviewdog/reviewdog.patch \
+ && mkdir -p $GOBIN \
+ && go install ./cmd/reviewdog \
+ && cd .. \
+ && rm -rf reviewdog \
+ && $GOBIN/reviewdog --version
+
+COPY entrypoint.sh /opt/antmicro/entrypoint.sh
+COPY action.py /opt/antmicro/action.py
+
+ENTRYPOINT ["/opt/antmicro/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: 'verible-linter'
 description: 'This action lints Verilog/SystemVerilog code'
 author: 'Antmicro'
+
 inputs:
   config_file:
     description: 'Relative path to configuration file'
@@ -25,63 +26,7 @@ inputs:
   reviewdog_reporter:
     description: '-reporter option to reviewdog'
     default: 'github-pr-review'
-runs:
-  using: 'composite'
-  steps:
-    - run: sudo apt update
-      shell: bash
-    - run: sudo apt install -y python3 wget python3-click golang-go
-      shell: bash
-    - run: mkdir verible && wget -qO- https://github.com/google/verible/releases/download/v0.0-1213-g9e5c085/verible-v0.0-1213-g9e5c085-Ubuntu-20.04-focal-x86_64.tar.gz | tar -zxvf - -C verible --strip-components=1
-      shell: bash
-    - run:  for i in $PWD/verible/bin/*; do sudo ln -s $i /bin/$(basename $i); done
-      shell: bash
-    - name: Install reviewdog
-      run: |
-        git clone https://github.com/reviewdog/reviewdog
-        cd reviewdog
-        git checkout 72c205e138df049330f2a668c33782cda55d61f6
-        git apply ${{ github.action_path }}/reviewdog.patch
-        mkdir ../bin
-        go build all
-        GOBIN=`pwd`/../bin go install ./cmd/reviewdog
-        cd ..
-        rm -rf reviewdog
-        ./bin/reviewdog --version
-      shell: bash
-    - run: |
-        event_file=event.json
-        diff_cmd="git diff FECH_HEAD"
-        if [ -f "$event_file" ]; then
-            pr_branch=$(cat event.json | \
-            python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['head']['ref'])")
-            base_branch=$(cat event.json | \
-            python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['base']['ref'])")
-            git fetch origin $pr_branch
-            git checkout $pr_branch
-            echo "the PR branch is $pr_branch"
-            echo "the base branch is $base_branch"
-            diff_cmd="git diff $base_branch $pr_branch" 
-            export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
-        fi
 
-        touch "${{ inputs.log_file }}"
-        export REVIEWDOG_GITHUB_API_TOKEN="${{ inputs.github_token }}"
-        ${{ github.action_path }}/action.py \
-        --conf-file "${{ inputs.config_file }}" \
-        --extra-opts "${{ inputs.extra_args }}" \
-        --exclude-paths "${{ inputs.exclude_paths }}" \
-        --log-file "${{ inputs.log_file }}" \
-        "${{ inputs.paths }}" || exitcode=$?
-        echo "Running reviewdog"
-        cat "${{ inputs.log_file }}" |
-        ./bin/reviewdog -efm="%f:%l:%c: %m" \
-        -reporter="${{ inputs.reviewdog_reporter }}" \
-        -fail-on-error="false" \
-        -name="verible-verilog-lint" \
-        -diff="$diff_cmd" || cat "${{ inputs.log_file }}"
-        if [ -f "$event_file" ]; then
-            git checkout -
-        fi
-        exit $exitcode
-      shell: bash
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+event_file=event.json
+diff_cmd="git diff FECH_HEAD"
+
+if [ -f "$event_file" ]; then
+  pr_branch=$(cat event.json | \
+  python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['head']['ref'])")
+
+  base_branch=$(cat event.json | \
+  python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['base']['ref'])")
+
+  git fetch origin $pr_branch
+  git checkout $pr_branch
+  echo "the PR branch is $pr_branch"
+  echo "the base branch is $base_branch"
+  diff_cmd="git diff $base_branch $pr_branch"
+  export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
+fi
+
+touch "$INPUT_LOG_FILE"
+export REVIEWDOG_GITHUB_API_TOKEN="$INPUT_GITHUB_TOKEN"
+
+/opt/antmicro/action.py \
+  --conf-file "$INPUT_CONFIG_FILE" \
+  --extra-opts "$INPUT_EXTRA_ARGS" \
+  --exclude-paths "$INPUT_EXCLUDE_PATHS" \
+  --log-file "$INPUT_LOG_FILE" \
+  "$INPUT_PATHS" || exitcode=$?
+
+echo "Running reviewdog"
+
+cat "$INPUT_LOG_FILE" |
+$GOBIN/reviewdog -efm="%f:%l:%c: %m" \
+  -reporter="$INPUT_REVIEWDOG_REPORTER" \
+  -fail-on-error="false" \
+  -name="verible-verilog-lint" \
+  -diff="$diff_cmd" \
+|| cat "$INPUT_LOG_FILE"
+
+if [ -f "$event_file" ]; then
+  git checkout -
+fi
+
+exit $exitcode


### PR DESCRIPTION
Close #3

Unfortunately, when the image is built automatically as part of a Container Action, it seems that global environment variables are not inherited. Therefore, enabling BuildKit globally through DOCKER_BUILDKIT does not work. That would be desirable in order to use https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#build-mounts-run---mount in the dockerfile. For now, I worked around it by using a COPY statement (a layer) instead. Nonetheless, I kept the commit isolated, because it might be reverted when building the image is decoupled from the execution.

I added a very simple CI workflow for testing the execution of the Action. Yet, since there is no "demo" project here, execution is rather useless. It would be interesting if someone familiar with Verible would contribute an example project in a follow-up PR.

NOTE: Since GitHub Actions is not enabled in this repository yet, results are not shown below. See https://github.com/umarcor/verible-linter-action/actions