### PR TITLE
Use autofix feature of Verible to suggest changes in PRs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir verible \
- && curl -fsSL https://github.com/google/verible/releases/download/v0.0-1213-g9e5c085/verible-v0.0-1213-g9e5c085-Ubuntu-20.04-focal-x86_64.tar.gz | tar -zxvf - -C verible --strip-components=1 \
- && for i in ./verible/bin/*; do ln -s $i /bin/$(basename $i); done
+ && curl -fsSL https://github.com/chipsalliance/verible/releases/download/v0.0-1343-gee63d53/verible-v0.0-1343-gee63d53-Ubuntu-20.04-focal-x86_64.tar.gz | tar -zxvf - -C verible --strip-components=1 \
+ && for i in ./verible/bin/*; do cp $i /bin/$(basename $i); done
 
 ENV GOBIN=/opt/go/bin
 
@@ -34,5 +34,6 @@ RUN git clone https://github.com/reviewdog/reviewdog \
 
 COPY entrypoint.sh /opt/antmicro/entrypoint.sh
 COPY action.py /opt/antmicro/action.py
+WORKDIR /opt/antmicro
 
 ENTRYPOINT ["/opt/antmicro/entrypoint.sh"]

--- a/action.py
+++ b/action.py
@@ -74,8 +74,10 @@ def find_sources_in_paths(paths):
               help='exclude these paths from the files to lint')
 @click.option('--log-file', '-l', type=str, required=False,
               help='log file name')
+@click.option('--patch', '-p', type=str, required=False,
+              help='patch file name')
 @click.argument('path', nargs=-1, required=True)
-def main(conf_file, extra_opts, exclude_paths, log_file, path):
+def main(conf_file, extra_opts, exclude_paths, log_file, patch, path):
     '''
     Lint .v and .sv files specified in PATHs
     '''
@@ -88,6 +90,13 @@ def main(conf_file, extra_opts, exclude_paths, log_file, path):
         extra_opts = extra_opts.split()
     else:
         extra_opts = []
+
+    if patch:
+        patch = ["--autofix=yes", "--autofix_output_file=" + patch]
+        # use this for newer version of Verible:
+        #patch = ["--autofix=patch", "--autofix_output_file=" + patch]
+    else:
+        patch = []
 
     paths = unwrap_from_gha_string(path)
     # set of target files to lint
@@ -102,7 +111,8 @@ def main(conf_file, extra_opts, exclude_paths, log_file, path):
         warnings.warn("File set is empty, the action has nothing to do.")
         exit()
 
-    command = ["verible-verilog-lint"] + conf_file + extra_opts + list(files)
+    command = (["verible-verilog-lint"]
+               + patch + conf_file + extra_opts + list(files))
     print("Running " + " ".join(command) + "\n\n")
     verible_linted = subprocess.run(command, capture_output=True)
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
   reviewdog_reporter:
     description: '-reporter option to reviewdog'
     default: 'github-pr-review'
+  suggest_fixes:
+    description: 'Post results of using --autofix option as change suggestions,
+                  works only with github-pre-review reporter'
+    default: 'true'
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,14 @@ event_file=event.json
 diff_cmd="git diff FECH_HEAD"
 
 if [ -f "$event_file" ]; then
-  pr_branch=$(cat event.json | \
-  python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['head']['ref'])")
-
-  base_branch=$(cat event.json | \
-  python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['base']['ref'])")
-
-  git fetch origin $pr_branch
-  git checkout $pr_branch
+  pr_branch=$(python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['head']['ref'])" < event.json)
+  base_branch=$(python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['base']['ref'])" < event.json)
+  git fetch origin "$pr_branch"
+  git checkout "$pr_branch"
   echo "the PR branch is $pr_branch"
   echo "the base branch is $base_branch"
   diff_cmd="git diff $base_branch $pr_branch"
-  export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
+  export OVERRIDE_GITHUB_EVENT_PATH=$(pwd)/event.json
 fi
 
 touch "$INPUT_LOG_FILE"
@@ -30,13 +26,11 @@ export REVIEWDOG_GITHUB_API_TOKEN="$INPUT_GITHUB_TOKEN"
 
 echo "Running reviewdog"
 
-cat "$INPUT_LOG_FILE" |
-$GOBIN/reviewdog -efm="%f:%l:%c: %m" \
+"$GOBIN"/reviewdog -efm="%f:%l:%c: %m" \
   -reporter="$INPUT_REVIEWDOG_REPORTER" \
   -fail-on-error="false" \
   -name="verible-verilog-lint" \
-  -diff="$diff_cmd" \
-|| cat "$INPUT_LOG_FILE"
+  -diff="$diff_cmd" < "$INPUT_LOG_FILE" || cat "$INPUT_LOG_FILE"
 
 if [ -f "$event_file" ]; then
   git checkout -


### PR DESCRIPTION
This PR enables creating automatic change suggestions.
Enabled by default, can be disabled by setting `suggest_fixes` input to value other than `true`.

Additionall changes are:
* newer version of Verible
* changes suggested by shellcheck linter