### PR TITLE
Push container image to GHCR and use it in the Action

### DIFF
--- a/.github/workflows/Container.yml
+++ b/.github/workflows/Container.yml
@@ -1,0 +1,33 @@
+name: Container
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 3'
+
+jobs:
+
+  container:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/chipsalliance/verible-linter-action
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Build container image
+      run: docker build -t $IMAGE .
+
+    - name: Login to GitHub Container Registry (GHCR)
+      if: github.event_name != 'pull_request' && github.repository == 'chipsalliance/verible-linter-action'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: gha
+        password: ${{ github.token }}
+
+    - name: Push container image to GitHub Container Registry (GHCR)
+      if: github.event_name != 'pull_request' && github.repository == 'chipsalliance/verible-linter-action'
+      run: docker push $IMAGE

--- a/action.yml
+++ b/action.yml
@@ -29,4 +29,4 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/chipsalliance/verible-linter-action'


### PR DESCRIPTION
This is a folloy-up of #4.

As commented in #3, building the container image separatedly and the using it at runtime can reduce the execution time for users of this Action. In this PR, a workflow is added, which builds image `ghcr.io/chipsalliance/verible-linter-action` and pushes it to the GitHub Container Registry, using the default token. Then, in the Action, that image is used instead of the `Dockerfile`.

- Current execution time (92s): https://github.com/chipsalliance/verible-linter-action/actions/runs/1192256099
- Image build and push time (131s): https://github.com/umarcor/verible-linter-action/actions/runs/1194493666
- Execution time using the image (22s): https://github.com/umarcor/verible-linter-action/actions/runs/1194493667

The workflows are scheduled weekly. Feel free to adjust that to your needs.

NOTE: CI will fail below because this PR does not have permission for pushing to ghcr.io/chipsalliance. That will work after this is merged to main. Precisely, workflow Container will work as soon as it is merged, and Test will need to be rerun afte the image is pushed for the first time. The references to my fork above did work because I temporarily used ghcr.io/umarcor instead.