### PR TITLE
Fix remote url handling when a PR from a fork is created

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,18 @@ diff_cmd="git diff FECH_HEAD"
 if [ -f "$event_file" ]; then
   pr_branch=$(python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['head']['ref'])" < event.json)
   base_branch=$(python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['base']['ref'])" < event.json)
-  git fetch origin "$pr_branch"
+  clone_url=$(python3 -c "import sys, json; print(json.load(sys.stdin)['pull_request']['head']['repo']['clone_url'])" < event.json)
+  echo "remotes:"
+  git remote -v
+  echo "adding new remote: $clone_url"
+  git remote add pr_repo "$clone_url"
+  echo "remotes:"
+  git remote -v
+  echo "fetching:"
+  git fetch pr_repo "$pr_branch"
   git checkout "$pr_branch"
+  echo "current HEAD is: "
+  git rev-parse HEAD
   echo "the PR branch is $pr_branch"
   echo "the base branch is $base_branch"
   diff_cmd="git diff $base_branch $pr_branch"


### PR DESCRIPTION
The action needs to handle two remotes. One for the main repo, and the other for the source of the PR.
This wasn't handled properly and is fixed here.
The problem appeared here:
https://github.com/lowRISC/ibex/pull/1434

Right now the script retrieves the URL of the remote from `event.json` and fetches the right branch from it.
Additionally, hash of the `HEAD` is printed so that it's easy to confirm correctness of operation.

I've checked these scenarios:
1. The branch used in a PR doesn't exist in the main repo, and it works.
2. The branch used in a PR does exist in the main repo, and it's actually fetched from the fork. (Previously the script tried to fetch it from mainline)