### PR TITLE
Fix missing output from action.py

### DIFF
--- a/action.py
+++ b/action.py
@@ -114,7 +114,7 @@ def main(conf_file, extra_opts, exclude_paths, log_file, patch, path):
     print("Running " + " ".join(command) + "\n\n")
     verible_linted = subprocess.run(command, capture_output=True)
 
-    issues = verible_linted.stdout.decode("utf-8")
+    issues = verible_linted.stderr.decode("utf-8")
     log_raw(issues, log_file if log_file else 'verible-verilog-lint.log')
 
     exit(issues != "")

--- a/action.py
+++ b/action.py
@@ -92,9 +92,7 @@ def main(conf_file, extra_opts, exclude_paths, log_file, patch, path):
         extra_opts = []
 
     if patch:
-        patch = ["--autofix=yes", "--autofix_output_file=" + patch]
-        # use this for newer version of Verible:
-        #patch = ["--autofix=patch", "--autofix_output_file=" + patch]
+        patch = ["--autofix=patch", "--autofix_output_file=" + patch]
     else:
         patch = []
 


### PR DESCRIPTION
The newer version of Verible: 
1. Prints rule violations to `stderr`, not `stdout` (This caused problems in Ibex repository).
2. Uses different values for autofix argument (I thought I had added this change already, and I'm adding it now).

A test PR was recreated here:
https://github.com/antmicro/gha-playground/pull/93