### PR TITLE
exit the action without error

### DIFF
--- a/action.py
+++ b/action.py
@@ -117,8 +117,6 @@ def main(conf_file, extra_opts, exclude_paths, log_file, patch, path):
     issues = verible_linted.stderr.decode("utf-8")
     log_raw(issues, log_file if log_file else 'verible-verilog-lint.log')
 
-    exit(issues != "")
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previously, the action would exit with non-zero code whenever rule violations were found, even if the violations did not belong to the changes in PR.
We could either change it to return non-zero when violations are relevant, or always return zero.
I'm changing this to always exit successfully and my reasoning here is that, if there are relevant violations, we'll see them in code review (so we don't really need the negative flag), and we can use non-zero exit codes for internal errors in the action, not related to output from Verible.