### PR TITLE
Add action input fail_on_error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Post results of using --autofix option as change suggestions,
                   works only with github-pre-review reporter'
     default: 'true'
+  fail_on_error:
+    description: 'Fail the action when rule violations are found'
+    default: 'false'
+
 
 runs:
   using: 'docker'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ if [ "$INPUT_SUGGEST_FIXES" = "true" ]; then
     --exclude-paths "$INPUT_EXCLUDE_PATHS" \
     --log-file "$INPUT_LOG_FILE" \
     --patch "$patch" \
-    "$INPUT_PATHS" || exitcode=$?
+    "$INPUT_PATHS"
 
   /opt/antmicro/rdf_gen.py \
     --efm-file "$INPUT_LOG_FILE" \
@@ -49,7 +49,7 @@ else
     --extra-opts "$INPUT_EXTRA_ARGS" \
     --exclude-paths "$INPUT_EXCLUDE_PATHS" \
     --log-file "$INPUT_LOG_FILE" \
-    "$INPUT_PATHS" || exitcode=$?
+    "$INPUT_PATHS"
 
   /opt/antmicro/rdf_gen.py \
     --efm-file "$INPUT_LOG_FILE" > "$rdf_log"
@@ -59,9 +59,9 @@ echo "Running reviewdog"
 
 "$GOBIN"/reviewdog -f=rdjson \
   -reporter="$INPUT_REVIEWDOG_REPORTER" \
-  -fail-on-error="false" \
+  -fail-on-error="$INPUT_FAIL_ON_ERROR" \
   -name="verible-verilog-lint" \
-  -diff="$diff_cmd" < "$rdf_log" || cat "$INPUT_LOG_FILE"
+  -diff="$diff_cmd" < "$rdf_log" || exitcode=$?
 
 if [ -f "$event_file" ]; then
   git checkout -


### PR DESCRIPTION
This allows to choose whether the action should fail or not, depending on the result of running Verible.
Use `fail_on_error: 'true'` to fail the action if a rule violation that is relevant to a PR exists.

For testing purposes, this PRs have been created:
1. Failing disabled, errors were posted as code review, but the workflow was successful anyway:
https://github.com/antmicro/gha-playground/pull/95
2. Failing enabled, errors were posted as code review and the workflow failed:
https://github.com/antmicro/gha-playground/pull/96
3. Failing enabled, but no rule violations were found, thus the workflow succeeded:
https://github.com/antmicro/gha-playground/pull/97