### PR TITLE
add GitHub token to test

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -17,3 +17,5 @@ jobs:
 
     - name: Test Action
       uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The test would fail because the default reporter is "github-pr-review" and there wasn't a token provided.
The reason I change the test, and not the code of the action, is because I assume that the correct usage of the action is to either:
1. Use a reporter that requires the token ("github-pr-review") AND provide the token.
2. Use a reporter that doesn't require the token (for example "local").

The workflow was successful here: https://github.com/antmicro/verible-linter-action/actions/runs/1266083502