### PR TITLE
Fix messages with colons

### DIFF
--- a/rdf_gen.py
+++ b/rdf_gen.py
@@ -110,7 +110,7 @@ def read_efm(filename):
         if len(data) > 4:
             # there are ':' inside the message part
             # merge the message part into one string
-            data = data[0:3] + [''.join(data[3:])]
+            data = data[0:3] + [':'.join(data[3:])]
 
         # now the data has 4 elements
         data = [elem.strip() for elem in data]


### PR DESCRIPTION
This should fix #15

The whole message was split on `:` and then joined with an empty string, which effectively removed all the colons.