### PR TITLE
Always use latest verible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir verible \
- && curl -fsSL https://github.com/chipsalliance/verible/releases/download/v0.0-1442-g27693bd/verible-v0.0-1442-g27693bd-Ubuntu-20.04-focal-x86_64.tar.gz | tar -zxvf - -C verible --strip-components=1 \
+ && curl -s https://api.github.com/repos/chipsalliance/verible/releases/latest | jq '.assets[] | select(.browser_download_url | contains("Ubuntu-20.04")).browser_download_url' | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1 \
  && for i in ./verible/bin/*; do cp $i /bin/$(basename $i); done
 
 ENV GOBIN=/opt/go/bin


### PR DESCRIPTION
Similar to the [verible-formatter-action](https://github.com/chipsalliance/verible-formatter-action), fetch the most recent version of `verible` and perform the linting.

Should the same arguments be used as before or should it be done the same way as the formatting action?

- `-f` fail fast without html error document
- `-S` shows an error message on fail
- `-L` follows a redirect