### PR TITLE
Download Verible prebuild for x86_64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir verible \
- && curl -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest | jq '.assets[] | select(.browser_download_url | contains("Ubuntu-20.04")).browser_download_url' | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1 \
+ && curl -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest | jq '.assets[] | select(.browser_download_url | test("(?=.*Ubuntu-20.04)(?=.*x86_64)")).browser_download_url' | xargs wget -qO- | tar -zxvf - -C verible --strip-components=1 \
  && for i in ./verible/bin/*; do cp $i /bin/$(basename $i); done
 
 ENV GOBIN=/opt/go/bin


### PR DESCRIPTION
Download script would only filter available downloads by target operating system, but not by architecture. Since Verible release [v0.0-2950-g1bb4ef62](https://github.com/chipsalliance/verible/releases/tag/v0.0-2950-g1bb4ef62) AArch64 builds became available, which were being downloaded despite the fact that container is being built for x86_64 platform.