### PR TITLE
rdf_gen: Use only start column number when parsing errorformat log

### DIFF
--- a/rdf_gen.py
+++ b/rdf_gen.py
@@ -112,6 +112,8 @@ def read_efm(filename):
             # merge the message part into one string
             data = data[0:3] + [':'.join(data[3:])]
 
+        data[2] = re.split("-", data[2])[0]
+
         # now the data has 4 elements
         data = [elem.strip() for elem in data]
         messages.append(


### PR DESCRIPTION
Current versions of Verible puts column range in the log, which breaks assumption that the log only contains first column where given error appears. This fix strips the last column number, fixing integer parsing error.