### PR TITLE
Simplify triggers usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,61 +58,37 @@ In GitHub Actions, workflows triggered by external repositories may only have
 [read access to the main repository](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token).
 In order to have automatic reviews on external PRs, you need to create two workflows.
 One will be triggered on ``pull_request`` and upload the data needed by reviewdog as an artifact.
-The artifact shall store the file pointed by ``$GITHUB_EVENT_PATH`` as ``event.json``.
+The artifact shall store the file pointed by ``$GITHUB_EVENT_PATH`` as ``verible-trigger.json``.
 The other workflow will download the artifact and use the Verible action.
 
 For example:
 ```yaml
-name: upload-event-file
+name: verible-trigger-send
 on:
   pull_request:
 
-...
-      - run: cp "$GITHUB_EVENT_PATH" ./event.json
-      - name: Upload event file as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: event.json
-          path: event.json
+jobs:
+  verible-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: antmicro/verible-linter-action/trigger-send@main
 ```
 
 ```yaml
-name: review-triggered
+
+name: verible-trigger-receive
 on:
   workflow_run:
-    workflows: ["upload-event-file"]
+    workflows: verible-trigger-send
     types:
       - completed
 
 jobs:
-  review_triggered:
+  verible-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: 'Download artifact'
-        id: get-artifacts
-        uses: actions/github-script@v3.1.0
-        with:
-          script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: ${{github.event.workflow_run.id }},
-            });
-            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "event.json"
-            })[0];
-            var download = await github.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            var fs = require('fs');
-            fs.writeFileSync('${{github.workspace}}/event.json.zip', Buffer.from(download.data));
-      - run: |
-          unzip event.json.zip
-      - name: Run Verible action with Reviewdog
+      - uses: antmicro/verible-linter-action/trigger-receive@main
+      - name: Run Verible action
         uses: chipsalliance/verible-linter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/trigger-receive/action.yml
+++ b/trigger-receive/action.yml
@@ -1,0 +1,7 @@
+name: 'verible-trigger-receive'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Download Event File
+      uses: chipsalliance/verible-actions-common/event-file-download@main

--- a/trigger-send/action.yml
+++ b/trigger-send/action.yml
@@ -1,0 +1,7 @@
+name: 'verible-trigger-send'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload Event File
+      uses: chipsalliance/verible-actions-common/event-file-upload@main


### PR DESCRIPTION
Hide all the details about artifacts and downloading from user. Users should not be required to copy the whole scripts to their workflows, let's keep then in a subaction in our repo so it's cleaner and easier to maintain.