### PR TITLE
Add linter log to artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,3 +73,8 @@ runs:
         INPUT_REVIEWDOG_REPORTER: ${{ inputs.reviewdog_reporter }}
         INPUT_SUGGEST_FIXES: ${{ inputs.suggest_fixes }}
       run: ${{ github.action_path }}/entrypoint.sh
+    - name: Upload linter log
+      uses: actions/upload-artifact@v3
+      with:
+        name: verible-linter
+        path: ${{ inputs.log_file }}


### PR DESCRIPTION
This pull request adds additional step in the action, which uploads full Verible linter log to artifacts.