### PR TITLE
Allow for overriding file extensions to be checked by linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can provide optional arguments to specify paths, exclude paths,
+You can provide optional arguments to specify paths, exclude paths, extensions of tested files,
 a config file, Verible version and extra arguments for ``verible-verilog-lint``.
 
 ```yaml
@@ -49,6 +49,11 @@ a config file, Verible version and extra arguments for ``verible-verilog-lint``.
       ./rtl/some_file
     extra_args: "--check_syntax=true"
     verible_version: "v0.0-3100-gd75b1c47"
+    extensions: |
+      .sv
+      .v
+      .vh
+      .svh
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   exclude_paths:
     description: 'Exclude these paths after finding all target files'
     required: false
+  extensions:
+    description: 'Run linting on files ending with following extensions'
+    required: false
+    default: ''
   log_file:
     description: 'Name for a log file'
     required: false
@@ -66,6 +70,7 @@ runs:
         INPUT_CONFIG_FILE: ${{ inputs.config_file }}
         INPUT_EXCLUDE_PATHS: ${{ inputs.exclude_paths }}
         INPUT_EXTRA_ARGS: ${{ inputs.extra_args }}
+        INPUT_EXTENSIONS: ${{ inputs.extensions }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_LOG_FILE: ${{ inputs.log_file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,7 @@ if [ "$INPUT_SUGGEST_FIXES" = "true" ]; then
     --conf-file "$INPUT_CONFIG_FILE" \
     --extra-opts "$INPUT_EXTRA_ARGS" \
     --exclude-paths "$INPUT_EXCLUDE_PATHS" \
+    --extensions "$INPUT_EXTENSIONS" \
     --log-file "$INPUT_LOG_FILE" \
     --patch "$patch" \
     "$INPUT_PATHS"
@@ -55,6 +56,7 @@ else
     --conf-file "$INPUT_CONFIG_FILE" \
     --extra-opts "$INPUT_EXTRA_ARGS" \
     --exclude-paths "$INPUT_EXCLUDE_PATHS" \
+    --extensions "$INPUT_EXTENSIONS" \
     --log-file "$INPUT_LOG_FILE" \
     "$INPUT_PATHS"
 


### PR DESCRIPTION
Currently action will only check files with `.sv` and `.v` extensions. Additional input parameter is introduced, called `extensions`, which can be used for overriding checked extensions set. This allows for adding e.g. include files to linting input.