### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
         INPUT_SUGGEST_FIXES: ${{ inputs.suggest_fixes }}
       run: ${{ github.action_path }}/entrypoint.sh
     - name: Upload linter log
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: verible-linter
         path: ${{ inputs.log_file }}


### PR DESCRIPTION
Version 3 is using Node v16 which is deprecated and may be removed in the future.

I'm unsure whether this change requires a major version bump to _this_ action. [upload-artifact@v4](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) changes whether the same artifact can be uploaded multiple times and replace itself which I suppose has an observable effect.