### PR TITLE
Fix print issue causing reviewdog to break

### DIFF
--- a/rdf_gen.py
+++ b/rdf_gen.py
@@ -179,7 +179,7 @@ def apply_fixes(err_messages, fixes):
         ]
 
         if not filtered_msgs:
-            #print(f'Did not find any errors to be solved by fix: {fix}') #Printing this line causes reviewdog to break like in issue #34
+            #Did not find any errors to be solved by fix
             continue
 
         filtered_msgs[0].fix(fix)

--- a/rdf_gen.py
+++ b/rdf_gen.py
@@ -179,7 +179,7 @@ def apply_fixes(err_messages, fixes):
         ]
 
         if not filtered_msgs:
-            print(f'Did not find any errors to be solved by fix: {fix}')
+            #print(f'Did not find any errors to be solved by fix: {fix}') #Printing this line causes reviewdog to break like in issue #34
             continue
 
         filtered_msgs[0].fix(fix)


### PR DESCRIPTION
when this condition is reached a plaintext line is printed to the log that reviewdog later parses. Reviewdog then spits out the error "reviewdog: parse error: failed to unmarshal rdjson (DiagnosticResult): proto: syntax error (line 1:1): invalid value Did"