### PR TITLE
Allow action to be used in multiple jobs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,11 @@ inputs:
   verible_version:
     description: 'Use selected Verible version (defaults to latest release)'
     default: 'latest'
+  artifact_name:
+    description: 'Artifact name for the uploaded linter log. Use a unique value
+                  per job to avoid collisions'
+    required: false
+    default: 'verible-linter'
 
 runs:
   using: 'composite'
@@ -81,5 +86,5 @@ runs:
     - name: Upload linter log
       uses: actions/upload-artifact@v4
       with:
-        name: verible-linter
+        name: ${{ inputs.artifact_name }}
         path: ${{ inputs.log_file }}


### PR DESCRIPTION
Previously using the action in multiple jobs as in:
```yaml
  verible-lint:
    name: Lint Verilog sources
    runs-on: ubuntu-latest
    if: >
      github.event_name != 'pull_request' ||
      github.event.pull_request.head.repo.full_name != github.repository
    steps:
      - uses: actions/checkout@v4
      - uses: colluca/verible-linter-action@main
        with:
          paths: |
            ./hw
          github_token: ${{ secrets.GITHUB_TOKEN }}
          fail_on_error: true
          reviewdog_reporter: github-check
          extra_args: "--waiver_files util/lint/waiver.verible"
          verible_version: "v0.0-3318-g8d254167"

  strict-verible-lint:
    name: Lint Verilog sources (strict)
    runs-on: ubuntu-latest
    if: >
      github.event_name != 'pull_request' ||
      github.event.pull_request.head.repo.full_name != github.repository
    steps:
      - uses: actions/checkout@v4
      - uses: colluca/verible-linter-action@main
        with:
          config_file: './util/lint/rules.verible'
          paths: |
            ./hw/schnizo
          github_token: ${{ secrets.GITHUB_TOKEN }}
          fail_on_error: true
          reviewdog_reporter: github-check
          extra_args: "--waiver_files util/lint/waiver.verible"
          verible_version: "v0.0-4051-g9fdb4057"
```

Would raise a `Failed to CreateArtifact` error, due to a conflict in the artifact name:
```
Conflict: an artifact with this name already exists on the workflow run
```